### PR TITLE
libeictoydetectors.so -> libeictoydetector.so

### DIFF
--- a/Fun4All_G4_Tracking.C
+++ b/Fun4All_G4_Tracking.C
@@ -52,7 +52,7 @@
 #include <TrackFastSimEval.h>
 #include "detector_setup.h"
 
-R__LOAD_LIBRARY(libeictoydetectors.so)
+R__LOAD_LIBRARY(libeictoydetector.so)
 // FIXME: add to CMakeLists.txt;
 R__LOAD_LIBRARY(libg4trackfastsim.so)
 R__LOAD_LIBRARY(libfun4all.so)


### PR DESCRIPTION
This PR fixes a typo in the name of the eictoydetector library (detector vs detectors). With that change the macro runs for me